### PR TITLE
Add Events Page and Remove Bootcamp Button from Navbar (Resolves #14)

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -4,7 +4,7 @@ import { Bars3Icon, XMarkIcon } from "@heroicons/react/24/outline";
 const navigation = [
   { name: "Home", href: "/", current: false },
   { name: "About", href: "#about", current: false },
-  { name: "Bootcamp", href: "/bootcamp", current: true },
+  { name: "Event", href: "/event", current: true },
 ];
 
 function classNames(...classes) {

--- a/src/components/landingPage/AboutUs.jsx
+++ b/src/components/landingPage/AboutUs.jsx
@@ -20,7 +20,7 @@ export default function AboutUs() {
 
       {/* Description */}
       <div className="max-w-6xl px-8  mt-14 sm:mt-20">
-        <p className=" text-xl sm:text-2xl font-normal sm:font-medium text-justify sm:text-center font-sans text-black">
+        <p className=" text-xl sm:text-2xl font-normal sm:font-medium text-justify font-sans text-black">
           The Computer Society Of India is a non-profit professional body that meets to exchange views and
           information to learn and share ideas. Being a national level committee, we work together to discuss
           technology with like-minded people. CSI is known for conducting a plethora of events ranging from

--- a/src/components/landingPage/WhyToJoin.jsx
+++ b/src/components/landingPage/WhyToJoin.jsx
@@ -46,7 +46,7 @@ function WhyToJoin() {
               <div className='text-[#003089] text-xl md:text-2xl'> 
                 {title}
               </div>
-              <div className='text-[#5D5D5D] text-start text-base md:text-xl font-productsans font-light'>
+              <div className='text-[#5D5D5D] text-justify text-base md:text-xl font-productsans font-light'>
                 {description}
               </div>
             </div>

--- a/src/screens/EventPage.jsx
+++ b/src/screens/EventPage.jsx
@@ -1,0 +1,16 @@
+import React, { useState, useEffect } from "react";
+
+const EventPage = () => {
+    return (
+        <section className="relative h-[calc(100vh)] bg-gradient-to-b from-[#C7DDFD] to-white">
+            <div className="relative z-10 flex flex-col justify-center items-center h-full text-center">
+                <h1 className=" text-3xl sm:text-4xl md:text-5xl font-bold mb-4 font-ethno text-primary p-5 shiny-text" data-text="NO EVENTS TO SHOW">
+                    <span className="inline">NO EVENTS </span>
+                    <span className="inline">TO SHOW</span>
+                </h1>
+            </div>
+        </section>
+    )
+}
+
+export default EventPage


### PR DESCRIPTION
This pull request addresses the feature request outlined in issue #14:

Added a new Events page to showcase the latest events. This page will be used to display upcoming and past events, replacing the current bootcamp-focused content.
Removed the Bootcamp button from the navbar as the bootcamp event has concluded and is no longer relevant.
These changes ensure that the website remains up to date by focusing on upcoming events.

Changes made:

Created EventPage.jsx for the exclusive events page.
Updated Navbar.jsx to remove the Bootcamp button.
Linked Issue: Resolves #14